### PR TITLE
Drools operator 'contains' in place of String.contains()

### DIFF
--- a/drools-docs/src/main/docbook/en-US/LanguageReference/Rule.xml
+++ b/drools-docs/src/main/docbook/en-US/LanguageReference/Rule.xml
@@ -1136,6 +1136,16 @@ CheeseCounter( cheeses contains $var ) // contains with a variable</programlisti
 
           <para>Only applies on <literal>Collection</literal>
           properties.</para>
+          
+          <para>The operator <literal>contains</literal> can also be used in place of <literal>String.contains()</literal>
+          constraints checks.</para>
+          
+          <example>
+            <title>Contains with String literals</title>
+            <programlisting>Cheese( name contains "tilto" )
+Person( fullName contains "Jr" )
+String( this contains "foo" )</programlisting>
+          </example>
         </section>
 
         <section>
@@ -1164,6 +1174,16 @@ CheeseCounter( cheeses not contains $var ) // not contains with a variable</prog
               for <literal>not contains</literal>.</para>
             </note>
           </blockquote>
+          
+          <para>The operator <literal>not contains</literal> can also be used in place of the logical negation of <literal>String.contains()</literal>
+          for constraints checks - i.e.: <literal>! String.contains()</literal></para>
+          
+          <example>
+            <title>Contains with String literals</title>
+            <programlisting>Cheese( name not contains "tilto" )
+Person( fullName not contains "Jr" )
+String( this not contains "foo" )</programlisting>
+          </example>
         </section>
 
         <section>


### PR DESCRIPTION
Drools operator 'contains' can also be used in place of String.contains()

With ref. to DROOLS-388 [1] and some quick tests, I'd like to propose doc changes as per this PR.

I've also pondered if to append Java-style comments to the proposed examples:

 <programlisting>Cheese( name contains "tilto" ) // Cheese.getName().contains("tilto")
Person( fullName contains "Jr" ) // Person.getFullName().contains("Jr")
String( this contains "foo" ) // "foobarbaz".contains("foo")</programlisting>

but given the Drools example are actually so simple, I think it may results being more confusing.

Thank you for review of this proposed doc changes.
Ciao
[1] https://issues.jboss.org/browse/DROOLS-388