### PR TITLE
Add /deployment/processes REST call

### DIFF
--- a/jbpm-asciidocs/src/main/asciidoc/RemoteAPI/REST-section.adoc
+++ b/jbpm-asciidocs/src/main/asciidoc/RemoteAPI/REST-section.adoc
@@ -587,6 +587,10 @@ deployment unit) may have changed by the time the user client receives the answe
 
 - Returns:: a list of all the available deployed instances in a `JaxbDeploymentUnitList` instance
 
+[GET] *`/deployment/processes`*
+
+- Returns a list of all the available deployed process definitions in a `JaxbProcessDefinitionList` instance
+
 [GET] *`/deployment/ _{deploymentId}_`*
 
 - Returns a `JaxbDeploymentUnit` instance containing the information (including the configuration) of the deployment unit.

--- a/jbpm-docs/src/main/docbook/en-US/RemoteAPI/REST-section.xml
+++ b/jbpm-docs/src/main/docbook/en-US/RemoteAPI/REST-section.xml
@@ -1364,6 +1364,15 @@ deployment unit) may have changed by the time the user client receives the answe
 </listitem>
 </itemizedlist>
 <simpara>[GET] <emphasis role="strong">
+<literal>/deployment/processes</literal>
+</emphasis>
+</simpara>
+<itemizedlist>
+<listitem>
+<simpara>Returns a list of all the available deployed process definitions in a <literal>JaxbProcessDefinitionList</literal> instance</simpara>
+</listitem>
+</itemizedlist>
+<simpara>[GET] <emphasis role="strong">
 <literal>/deployment/ <emphasis>{deploymentId}</emphasis>
 </literal>
 </emphasis>


### PR DESCRIPTION
Add /deployment/processes REST call which is already implemented in DeploymentsResourceImpl.

(docbook is generated from adoc following the guidance in https://issues.jboss.org/browse/JBPM-4568)
