### PR TITLE
KieScanner behavior for already existing KieBases and KieSessions

### DIFF
--- a/shared/KIE/BuildDeployUtilizeAndRun/KIEDeploying.xml
+++ b/shared/KIE/BuildDeployUtilizeAndRun/KIEDeploying.xml
@@ -88,11 +88,20 @@ kScanner.start( 10000L );</programlisting>
 
     <para>In this example the <code>KieScanner</code> is configured to run with a fixed
     time interval, but it is also possible to run it on demand by invoking the
-    <code>scanNow()</code> method on it. If the <code>KieScanner</code> finds in the
-    Maven repository an updated version of the Kie project used by that <code>KieContainer</code>
+    <code>scanNow()</code> method on it. If the <code>KieScanner</code> finds, in the
+    Maven repository, an updated version of the Kie project used by that <code>KieContainer</code>
     it automatically downloads the new version and triggers an incremental build of the new
-    project. From this moment all the new <code>KieBase</code>s and <code>KieSession</code>s
-    created from that <code>KieContainer</code> will use the new project version.</para>
+    project.
+    At this point, existing <code>KieBase</code>s and <code>KieSession</code>s under the control of <code>KieContainer</code>
+    will get automatically upgraded with it - specifically, those <code>KieBase</code>s obtained with <code>getKieBase()</code>
+    along with their related <code>KieSession</code>s, and any <code>KieSession</code> obtained directly with
+    <code>KieContainer.newKieSession()</code> thus referencing the default <code>KieBase</code>.
+    Additionally, from this moment on, all the new <code>KieBase</code>s and <code>KieSession</code>s
+    created from that <code>KieContainer</code> will use the new project version.
+    Please notice however any existing <code>KieBase</code> which was obtained via <code>newKieBase()</code> before the
+    KieScanner upgrade, and any of its related <code>KieSession</code>s, will not get automatically upgraded; this is because
+    <code>KieBase</code>s obtained via <code>newKieBase()</code> are not under the direct control of the <code>KieContainer</code>.
+    </para>
     <para>The <code>KieScanner</code> will only pickup changes to deployed jars if it is using a SNAPSHOT, version range,
     the LATEST, or the RELEASE setting. Fixed versions will not automatically update at runtime.</para>
   </section>


### PR DESCRIPTION
With reference to Drools-usage Google group discussion Ref.
https://groups.google.com/d/topic/drools-usage/XpFlRNjuc9c/discussion

Report below summary for reference.

I think statement is missing to describe
what happens to already existing KieSession and KieBase; from the
current description I would have assumed only "new" stuff gets
up-to-date, but (fortunately!) also some type of already-existing
KieSession and KieBase gets automatically updated.

Current behavior "From this moment on" proved by code actually is:

1- already existing KieBase, generated with getKieBase() : it does get
automatically updated. This is the use case of named KieBase or default
KieBase referenced from kmodule.xml 

2- already existing KieBase, generated with newKieBase() : NOT
automatically updated. This is the use case of KieBase created with
"custom" KieBaseConfiguration settings and NOT referencing kmodule.xml

3- any KieBase generated after the KieScanner updated, with either
getKieBase() or newKieBase() : directly the newer version, simple case,
indeed as already mentioned in the documentation.

Behavior for already existing KieSession depends on the underlying
KieBase, so it make reference to the cases described here-above. 
To be fully explicit, when already existing KieSession was generated
directly from KieContainer.newKieSession() is case #1 because it implies
the default KieBase from kmodule.xml.