### PR TITLE
[6.4.x] BPMSPL-252: [GSS-RFE] Ability to check duplicate of ReleaseId (GroupId, ArtifactId and Version) with existing projects. Updates following QE feedback.

### DIFF
--- a/shared/Workbench/Authoring/ProjectEditor/ProjectEditor.xml
+++ b/shared/Workbench/Authoring/ProjectEditor/ProjectEditor.xml
@@ -164,6 +164,11 @@
     <para>When performing any of the following operations a check is now made against all Maven Repositories, resolved for the Project, 
       for whether the Project's GroupId, ArtifactId and Version pre-exist. If a clash is found the operation is prevented; although this can be overridden by Users
       with the <code>admin</code> role.</para>
+
+    <note>
+      <para>The feature can be disabled by setting the System Property <code>org.guvnor.project.gav.check.disabled</code> to <code>true</code>.</para>
+    </note>
+
     <para>Resolved repositories are those discovered in:-
       <itemizedlist>
         <listitem>

--- a/shared/Workbench/Installation/Installation.xml
+++ b/shared/Workbench/Installation/Installation.xml
@@ -164,6 +164,10 @@
       </listitem>
 
       <listitem>
+        <para><emphasis role="bold"><literal>org.guvnor.project.gav.check.disabled</literal></emphasis>: Disable GAV checks. Default: <literal>false</literal></para>
+      </listitem>
+
+      <listitem>
         <para><emphasis role="bold"><literal>org.kie.example.repositories</literal></emphasis>: Folder from where demo
           repositories will be cloned. The demo repositories need to have been obtained and placed in this folder. Demo
           repositories can be obtained from the kie-wb-6.2.0-SNAPSHOT-example-repositories.zip artifact. This System

--- a/shared/Workbench/ReleaseNotes/ReleaseNotesWorkbench.6.4.0.Final.xml
+++ b/shared/Workbench/ReleaseNotes/ReleaseNotesWorkbench.6.4.0.Final.xml
@@ -80,6 +80,11 @@
     <para>When performing any of the following operations a check is now made against all Maven Repositories, resolved for the Project, 
       for whether the Project's GroupId, ArtifactId and Version pre-exist. If a clash is found the operation is prevented; although this can be overridden by Users
       with the <code>admin</code> role.</para>
+
+    <note>
+      <para>The feature can be disabled by setting the System Property <code>org.guvnor.project.gav.check.disabled</code> to <code>true</code>.</para>
+    </note>
+    
     <para>Resolved repositories are those discovered in:-
       <itemizedlist>
         <listitem>


### PR DESCRIPTION
See https://issues.jboss.org/browse/BPMSPL-252

(cherry picked from commit 7962a9941df22806fe3084a0dc5131fc8572593b)

Corollary of https://github.com/droolsjbpm/kie-docs/pull/47