### PR TITLE
[6.4.x] BZ1299619: Business Central Repo Clone Fails To Clone SCP Style SSH URLs

### DIFF
--- a/shared/Workbench/Installation/Installation.xml
+++ b/shared/Workbench/Installation/Installation.xml
@@ -112,8 +112,14 @@
 
       <listitem>
         <para><emphasis role="bold"><literal>org.uberfire.nio.git.ssh.cert.dir</literal></emphasis>:
-          Location of the directory <literal>.security</literal> where local certtificates will be
+          Location of the directory <literal>.security</literal> where local certificates will be
           stored. Default: working directory</para>
+      </listitem>
+
+      <listitem>
+        <para><emphasis role="bold"><literal>org.uberfire.nio.git.ssh.passphrase</literal></emphasis>:
+          Passphrase to access your Operating Systems public keystore when cloning <literal>git</literal> repositories with <literal>scp</literal> style URLs;
+          e.g. <literal>git@github.com:user/repository.git</literal>.</para>
       </listitem>
 
       <listitem>

--- a/shared/Workbench/ReleaseNotes/ReleaseNotesWorkbench.6.4.0.Final.xml
+++ b/shared/Workbench/ReleaseNotes/ReleaseNotesWorkbench.6.4.0.Final.xml
@@ -74,6 +74,12 @@
       automatic build can now be disabled with the <code>org.kie.build.disable-project-explorer</code> System Property. Set the value 
       to <code>true</code> to disable. The default value is <code>false</code>.</para>
   </section>
+
+  <section>
+    <title>Support for <literal>SCP</literal> style <literal>git</literal> Repository URLs</title>
+    <para>When cloning <literal>git</literal> Repositories it is now possible to use <literal>SCP</literal> style URLS, for example <literal>git@github.com:user/repository.git</literal>. 
+    If your Operating System's public keystore is password protected the passphrase can be provided with the <literal>org.uberfire.nio.git.ssh.passphrase</literal> System Property.</para>
+  </section>
   
   <section>
     <title>Authoring - Duplicate GAV detection</title>


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1299619

This is the corollary of https://github.com/droolsjbpm/kie-docs/pull/51 for 6.4.x.

(cherry picked from commit 0ad5346afa79250460a3dd0bc9c48c4920c6ace5)