### PR TITLE
[6.3.x] BZ1299870: [GSS](6.2.z) Business Central Repo Clone Fails To Clone SCP Style SSH URLs

### DIFF
--- a/shared/Workbench/Installation/Installation.xml
+++ b/shared/Workbench/Installation/Installation.xml
@@ -98,6 +98,12 @@
         <para><emphasis role="bold"><literal>org.uberfire.nio.git.ssh.port</literal></emphasis>: If ssh daemon enabled,
           uses this property as port number. Default: <literal>8001</literal></para>
       </listitem>
+
+      <listitem>
+        <para><emphasis role="bold"><literal>org.uberfire.nio.git.ssh.passphrase</literal></emphasis>:
+          Passphrase to access your Operating Systems public keystore when cloning <literal>git</literal> repositories with <literal>scp</literal> style URLs;
+          e.g. <literal>git@github.com:user/repository.git</literal>.</para>
+      </listitem>
       
       <listitem>
         <para><emphasis role="bold"><literal>org.uberfire.nio.git.ssh.cert.dir</literal></emphasis>: Location of the directory


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1299870

This is the corollary of https://github.com/droolsjbpm/kie-docs/pull/51 for 6.3.x.

NOTE 6.3.x has a different BZ number but the fix is the same.

(cherry picked from commit 0ad5346afa79250460a3dd0bc9c48c4920c6ace5)

Conflicts:
	shared/Workbench/Installation/Installation.xml