### PR TITLE
GUVNOR-2335 - adding documentation about the 'org.uberfire.nio.git.hooks' property used to add Git hook scripts to repositories

### DIFF
--- a/shared/Workbench/Installation/Installation.xml
+++ b/shared/Workbench/Installation/Installation.xml
@@ -115,6 +115,11 @@
           Location of the directory <literal>.security</literal> where local certificates will be
           stored. Default: working directory</para>
       </listitem>
+      
+      <listitem>
+        <para><emphasis role="bold"><literal>org.uberfire.nio.git.hooks</literal></emphasis>: Location of the directory that contains 
+			Git hook scripts that are installed into each repository created (or cloned) in the Workbench. Default: N/A</para>
+      </listitem>
 
       <listitem>
         <para><emphasis role="bold"><literal>org.uberfire.nio.git.ssh.passphrase</literal></emphasis>:


### PR DESCRIPTION
@psiroky Please merge? 

Thanks!