### PR TITLE
6.4.x - Change incorrect URL

### DIFF
--- a/shared/KieServer/Install.xml
+++ b/shared/KieServer/Install.xml
@@ -38,7 +38,7 @@
         <example>
           <title>Sample handshaking server response</title>
           <programlisting language="XML">&lt;response type="SUCCESS" msg="KIE Server info">
-  &lt;kie-server-info>  
+  &lt;kie-server-info>
     &lt;version>&project.version;&lt;/version>
   &lt;/kie-server-info>
 &lt;/response></programlisting>
@@ -117,7 +117,7 @@
                   >org.kie.server.controller</emphasis></entry>
               <entry>comma separated list of urls</entry>
               <entry>List of urls to controller REST endpoint. E.g.:
-                  <code>http://localhost:8080/kie-wb/rest</code></entry>
+                  <code>http://localhost:8080/kie-wb/rest/controller</code></entry>
               <entry>Yes when using a controller</entry>
             </row>
             <row>
@@ -297,9 +297,9 @@
         </tgroup>
       </table>
       <important>
-        <para>If you are running both KIE Server and KIE Workbench you must configure KIE Server to use a different Data Source to KIE Workbench using the 
-          <emphasis role="bold">org.kie.server.persistence.ds</emphasis> property. KIE Workbench uses a jBPM Executor Service that can conflict with 
-          KIE Server if they share the same Data Source.</para>        
+        <para>If you are running both KIE Server and KIE Workbench you must configure KIE Server to use a different Data Source to KIE Workbench using the
+          <emphasis role="bold">org.kie.server.persistence.ds</emphasis> property. KIE Workbench uses a jBPM Executor Service that can conflict with
+          KIE Server if they share the same Data Source.</para>
       </important>
     </para>
   </section>
@@ -334,7 +334,7 @@
               check out the Tomcat logs in <code>TOMCAT_HOME/logs</code> to see if the application
               deployed successfully. Please read the table above for the bootstrap switches that can
               be used to properly configure the instance. For
-              instance:<programlisting>./startup.sh -Dorg.kie.server.id=first-kie-server 
+              instance:<programlisting>./startup.sh -Dorg.kie.server.id=first-kie-server
              -Dorg.kie.server.location=http://localhost:8080/kie-server/services/rest/server</programlisting></para>
           </listitem>
           <listitem>
@@ -376,9 +376,9 @@
               output or WildFly logs in <code>WILDFLY_HOME/standalone/logs</code> to see if the
               application deployed successfully. Please read the table above for the bootstrap
               switches that can be used to properly configure the instance. For
-              instance:<programlisting>./standalone.sh  --server-config=standalone-full.xml 
+              instance:<programlisting>./standalone.sh  --server-config=standalone-full.xml
                  -Djboss.socket.binding.port-offset=150
-                 -Dorg.kie.server.id=first-kie-server 
+                 -Dorg.kie.server.id=first-kie-server
                  -Dorg.kie.server.location=http://localhost:8230/kie-server/services/rest/server</programlisting></para>
           </listitem>
           <listitem>


### PR DESCRIPTION
Hi,

I saw a bug report for an [incorrect URL](https://bugzilla.redhat.com/show_bug.cgi?id=1270787). I think this changes it, correct? 

This is upstream issue only. Hope this helps a bit.