### PR TITLE
DROOLS-1232 calling getQueryResults() from RHS would hang indefinitely.

### DIFF
--- a/drools-asciidocs/src/main/asciidoc/LanguageReference/Rule-section.adoc
+++ b/drools-asciidocs/src/main/asciidoc/LanguageReference/Rule-section.adoc
@@ -2887,7 +2887,7 @@ kcontext.getKieRuntime().getAgenda().getAgendaGroup( "CleanUp" ).setFocus();
 +
 (You can achieve the same using ``drools.setFocus(
 "CleanUp" )``.)
-* To run a query, you call ``getQueryResults(String query)``, whereupon you may process the results, as explained in section <<_querysection,Query>>.
+* To run a query, you call `getQueryResults(String query)`, whereupon you may process the results, as explained in section <<_querysection,Query>>. Using `kcontext.getKieRuntime().getQueryResults()` or using `drools.getKieRuntime().getQueryResults()` is the proper method of running a query from a rule's RHS, and the only supported way.
 * A set of methods dealing with event management lets you, among other things, add and remove event listeners for the Working Memory and the Agenda.
 * Method `getKieBase()` returns the `KieBase` object, the backbone of all the Knowledge in your system, and the originator of the current session.
 * You can manage globals with ``setGlobal(...)``, `getGlobal(...)` and ``getGlobals()``.

--- a/drools-docs/src/main/docbook/en-US/LanguageReference/Rule.xml
+++ b/drools-docs/src/main/docbook/en-US/LanguageReference/Rule.xml
@@ -3582,7 +3582,10 @@ kcontext.getKieRuntime().getAgenda().getAgendaGroup( "CleanUp" ).setFocus();</pr
           <para>To run a query, you call <code>getQueryResults(String
           query)</code>, whereupon you may process the results, as explained
           in section <link endterm="QuerySection"
-          linkend="QuerySection">Query</link>.</para>
+          linkend="QuerySection">Query</link>. Using <code>kcontext.getKieRuntime().getQueryResults(...)</code>
+          or using <code>drools.getKieRuntime().getQueryResults(...)</code> is the
+          proper method of running a query from a rule's RHS, and the only supported way.
+          </para>
         </listitem>
 
         <listitem>


### PR DESCRIPTION
Make explicit full-extended call to method is the proper way for 
running a query from a rule's RHS.

Make explicit the full-extended call to method is the only supported
method for running a query from a rule's RHS.