### PR TITLE
DROOLS-1232 calling getQueryResults() from RHS would hang indefinitely.

### DIFF
--- a/drools-docs/src/main/docbook/en-US/LanguageReference/Rule.xml
+++ b/drools-docs/src/main/docbook/en-US/LanguageReference/Rule.xml
@@ -3583,7 +3583,10 @@ kcontext.getKieRuntime().getAgenda().getAgendaGroup( "CleanUp" ).setFocus();</pr
           <para>To run a query, you call <code>getQueryResults(String
           query)</code>, whereupon you may process the results, as explained
           in section <link endterm="QuerySection"
-          linkend="QuerySection">Query</link>.</para>
+          linkend="QuerySection">Query</link>. Using <code>kcontext.getKieRuntime().getQueryResults(...)</code>
+          or using <code>drools.getKieRuntime().getQueryResults(...)</code> is the
+          proper method of running a query from a rule's RHS, and the only supported way.
+          </para>
         </listitem>
 
         <listitem>


### PR DESCRIPTION
Make explicit full-extended call to method is the proper way for 
running a query from a rule's RHS.

Make explicit the full-extended call to method is the only supported
method for running a query from a rule's RHS.