### PR TITLE
Move TOC to left side of the page

### DIFF
--- a/drools-docs/src/main/asciidoc/index.adoc
+++ b/drools-docs/src/main/asciidoc/index.adoc
@@ -12,12 +12,12 @@
 // Content
 
 = Drools Documentation
-:toc: preamble
+:toc: left
 :toclevels: 3
 
 [.lead]
 image::droolsExpertLogo.png[align="left"]
-link:http://www.drools.org/community/team.html[The Jboss Drools Team] +
+link:https://www.drools.org/community/team.html[The JBoss Drools Team] +
 {project-version}
 
 ////

--- a/jbpm-docs/src/main/asciidoc/index.adoc
+++ b/jbpm-docs/src/main/asciidoc/index.adoc
@@ -12,12 +12,12 @@
 // Content
 
 = jBPM Documentation
-:toc: preamble
+:toc: left
 :toclevels: 3
 
 [.lead]
 image::jBPMLogo.png[align="left"]
-link:http://www.drools.org/community/team.html[The Jboss jBPM Team] +
+link:https://www.jbpm.org/community/team.html[The JBoss jBPM Team] +
 {project-version}
 
 [discrete]

--- a/optaplanner-wb-es-docs/src/main/asciidoc/index.adoc
+++ b/optaplanner-wb-es-docs/src/main/asciidoc/index.adoc
@@ -12,7 +12,7 @@
 // Content
 
 = OptaPlanner Workbench and Execution Server User Guide
-:toc: preamble
+:toc: left
 :toclevels: 3
 
 [.lead]


### PR DESCRIPTION
 * TOC was previously before the content. Since
   the displays are wide enough these days, movfing
   the TOC to left is great way to make navigation
   in the docs easier

This is how it looks like:
![jbpm-docs-toc-left](https://cloud.githubusercontent.com/assets/670547/17768030/90eb54e6-6532-11e6-95c0-5a4456e2f59d.png)
