### PR TITLE
Document additional workaround for 'hanging' loading of Workbench

### DIFF
--- a/shared/Workbench/Installation/Installation-section.adoc
+++ b/shared/Workbench/Installation/Installation-section.adoc
@@ -110,3 +110,7 @@ The issue results in the "Loading..." spinner remaining visible and the Workbenc
 
 The workaround is to disable the Workbench's use of Server Sent Events by adding file `/WEB-INF/classes/ErraiService.properties` to the exploded WAR containing the value ``errai.bus.enable_sse_support=false``.
 Re-package the WAR and re-deploy.
+
+Some Users have also reported disabling Server Sent Events does not resolve the issue. The solution found to work is to configure the JVM to use a different Entropy Gathering Device on Linux for `SecureRandom`. This can be configured by setting System Property `java.security.egd` to `file:/dev/./urandom`. See http://stackoverflow.com/questions/33166198/kie-workbench-not-loading-after-login/39110177#39110177[this]  Stack Overflow post for details.
+
+Please note however this affects the JVM's random  number generation and may present other challenges where strong cryptography is required. Configure with caution.


### PR DESCRIPTION
See https://groups.google.com/forum/#!topic/drools-setup/fx67PiV5uMs

Document alternative workaround for "Loading..." hanging.

@csadilek Would you mind reviewing?