### PR TITLE
Fix asciidoctor warnings

### DIFF
--- a/drools-docs/src/main/asciidoc/ComplexEventProcessing/TemporalReasoning-section.adoc
+++ b/drools-docs/src/main/asciidoc/ComplexEventProcessing/TemporalReasoning-section.adoc
@@ -9,14 +9,10 @@ There are hundreds of papers and thesis written and approaches are described for
 Drools once more takes a pragmatic and simple approach based on several sources, but specially worth noting the following papers:
 
 [bibliography]
-
-[[[ALLEN81]]] Allen, J.F.. _An Interval-based Representation of Temporal Knowledge_. 1981.
-
-[[[ALLEN83]]] Allen, J.F.. _Maintaining knowledge about temporal intervals_. 1983.
-
-[[[BENNE00]]] Bennet, Brandon and Galton, Antony P.. _A Unifying Semantics for Time and Events_. 2005.
-
-[[[YONEK05]]] Yoneki, Eiko and Bacon, Jean. _Unified Semantics for Event Correlation Over Time and Space in Hybrid Network Environments_. 2005.
+- [[[ALLEN81]]] Allen, J.F.. _An Interval-based Representation of Temporal Knowledge_. 1981.
+- [[[ALLEN83]]] Allen, J.F.. _Maintaining knowledge about temporal intervals_. 1983.
+- [[[BENNE00]]] Bennet, Brandon and Galton, Antony P.. _A Unifying Semantics for Time and Events_. 2005.
+- [[[YONEK05]]] Yoneki, Eiko and Bacon, Jean. _Unified Semantics for Event Correlation Over Time and Space in Hybrid Network Environments_. 2005.
 
 Drools implements the Interval-based Time Event Semantics described by Allen, and represents Point-in-Time Events as Interval-based evens with duration 0 (zero).
 

--- a/jbpm-docs/src/main/asciidoc/TaskService/TaskServiceAPIs-section.adoc
+++ b/jbpm-docs/src/main/asciidoc/TaskService/TaskServiceAPIs-section.adoc
@@ -77,7 +77,7 @@ Because the content of the Task can be any Object, the previous method assume th
 If you are storing other than a Map you should do the correspondent checks. 
 
 
-=== Task event listener
+== Task event listener
 
 Task service supports task listeners to be invoked upon various life cycle events happening on given task instance. In majority of cases task event listeners are used to intercept certain operation to perform additional logic - like storing task information in separate tables for business activity monitoring needs. 
 

--- a/shared/Spring/KieSpring-chapter.adoc
+++ b/shared/Spring/KieSpring-chapter.adoc
@@ -1123,7 +1123,7 @@ An instance of a `JpaTransactionManager` bean is also instantiated because of th
 ====
 [source,xml]
 ----
-include::{sourcedir}/Spring/examples/spring-human-task-example.xml[]
+include::{shared-dir}/Spring/examples/spring-human-task-example.xml[]
 ----
 ====
 


### PR DESCRIPTION
Running `mvn clean install` in kie-docs emits the following asciidoctor warnings.
This PR fixes them

    asciidoctor: WARNING: ComplexEventProcessing/TemporalReasoning-section.adoc: line 13: invalid style for paragraph: bibliography
    asciidoctor: WARNING: dropping line containing reference to missing attribute: sourcedir
    asciidoctor: WARNING: TaskService/TaskServiceAPIs-section.adoc: line 80: section title out of sequence: expected level 3, got level 4