### PR TITLE
Minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 /*.iws
 /*.iml
 
+# Repository wide ignore mac DS_Store files
+.DS_Store
+
 # Oxygen project files
 /**/*.xpr
 

--- a/docs/shared/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.0.0.Final-section.adoc
+++ b/docs/shared/Workbench/ReleaseNotes/ReleaseNotesWorkbench.7.0.0.Final-section.adoc
@@ -45,9 +45,11 @@ image::shared/Workbench/ReleaseNotes/examples-wizard4.png[]
 All system pop-ups had their UX improved.
 
 The "comment" field is hidden by default.
+
 image::shared/Workbench/ReleaseNotes/popups-comment-field.png[]
 
 Now, the destination package can be selected when a project file is copied from any package.
+
 image::shared/Workbench/ReleaseNotes/popups-package-field.png[]
 
 


### PR DESCRIPTION
- Made the images visible for "GUVNOR-2431: Redesign Copy, Save, Rename, Restore and Delete Popups"
- Added the OSX .DS_Store to .gitignore