### PR TITLE
Fix code formatting block for the examples of the "Type Declaration" …

### DIFF
--- a/docs/drools-docs/topics/LanguageReference/TypeDeclaration-section.adoc
+++ b/docs/drools-docs/topics/LanguageReference/TypeDeclaration-section.adoc
@@ -41,14 +41,14 @@ For instance, we may want to declare another fact type ``Person``:
 
 .declaring a new fact type: Person
 ====
-++++
-<programlisting><emphasis role="bold">declare</emphasis> Person
+[source]
+----
+declare Person
     name : String
     dateOfBirth : java.util.Date
     address : Address
-<emphasis role="bold">end</emphasis>
-</programlisting>
-++++
+end
+----
 ====
 
 
@@ -58,15 +58,16 @@ You may avoid having to write the fully qualified name of a class every time you
 
 .Avoiding the need to use fully qualified class names by using import
 ====
-++++
-<programlisting><emphasis role="bold">import</emphasis> java.util.Date
+[source]
+----
+import java.util.Date
 
-<emphasis role="bold">declare</emphasis> Person
+declare Person
     name : String
     dateOfBirth : Date
     address : Address
-<emphasis role="bold">end</emphasis></programlisting>
-++++
+end
+----
 ====
 
 
@@ -104,17 +105,18 @@ Since the generated class is a simple Java class, it can be used transparently i
 
 .Using the declared types in rules
 ====
-++++
-<programlisting><emphasis role="bold">rule</emphasis> "Using a declared Type"
-<emphasis role="bold">when</emphasis> 
+[source]
+----
+rule "Using a declared Type"
+when< 
     $p : Person( name == "Bob" )
-<emphasis role="bold">then</emphasis>
-    <emphasis>// Insert Mark, who is Bob's mate.</emphasis>
+then
+    // Insert Mark, who is Bob's mate.
     Person mark = new Person();
     mark.setName("Mark");
     insert( mark );
-<emphasis role="bold">end</emphasis></programlisting>
-++++
+end
+----
 ====
 
 === Declaring enumerative types
@@ -124,17 +126,18 @@ DRL also supports the declaration of enumerative types.
 Such type declarations require the additional keyword __enum__, followed by a comma separated list of admissible values terminated by a semicolon. 
 
 ====
-++++
-<programlisting><emphasis role="bold">rule</emphasis> "Using a declared Type"
-<emphasis role="bold">when</emphasis> 
+[source]
+----
+rule "Using a declared Type"
+when 
     $p : Person( name == "Bob" )
-<emphasis role="bold">then</emphasis>
-    <emphasis>// Insert Mark, who is Bob's mate.</emphasis>
+then
+    // Insert Mark, who is Bob's mate.
     Person mark = new Person();
     mark.setName("Mark");
     insert( mark );
-<emphasis role="bold">end</emphasis></programlisting>
-++++
+end
+----
 ====
 
 
@@ -144,13 +147,14 @@ Complex enums are also partially supported, declaring the internal fields simila
 Notice that as of version 6.x, enum fields do _NOT_ support other declared types or enums
 
 ====
-++++
-<programlisting><emphasis role="bold">declare enum</emphasis> DaysOfWeek
+[source]
+----
+declare enum DaysOfWeek
    SUN("Sunday"),MON("Monday"),TUE("Tuesday"),WED("Wednesday"),THU("Thursday"),FRI("Friday"),SAT("Saturday");
 
    fullName : String
-<emphasis role="bold">end</emphasis></programlisting>
-++++
+end
+----
 ====
 
 
@@ -158,14 +162,15 @@ Enumeratives can then be used in rules
 
 .Using declarative enumerations in rules
 ====
-++++
-<programlisting><emphasis role="bold">rule</emphasis> "Using a declared Enum"
-<emphasis role="bold">when</emphasis>
+[source]
+----
+rule "Using a declared Enum"
+when
    $p : Employee( dayOff == DaysOfWeek.MONDAY )
-<emphasis role="bold">then</emphasis>
+then
    ...
-<emphasis role="bold">end</emphasis></programlisting>
-++++
+end
+----
 ====
 
 == Declaring Metadata
@@ -199,18 +204,19 @@ Any metadata that is declared before the attributes of a fact type are assigned 
 
 .Declaring metadata attributes for fact types and attributes
 ====
-++++
-<programlisting><emphasis role="bold">import</emphasis> java.util.Date
+[source]
+----
+import java.util.Date
 
-<emphasis role="bold">declare</emphasis> Person
-    <emphasis>@author</emphasis>( Bob )
-    <emphasis>@dateOfCreation</emphasis>( 01-Feb-2009 )
+declare Person
+    @author( Bob )
+    @dateOfCreation( 01-Feb-2009 )
 
-    name : String <emphasis>@key @maxLength</emphasis>( 30 )
+    name : String @key @maxLength( 30 )
     dateOfBirth : Date 
     address : Address
-<emphasis role="bold">end</emphasis></programlisting>
-++++
+end
+----
 ====
 
 
@@ -236,13 +242,14 @@ The following example declares that the fact type StockTick in a stock broker ap
 
 .declaring a fact type as an event
 ====
-++++
-<programlisting><emphasis role="bold">import</emphasis> some.package.StockTick
+[source]
+----
+import some.package.StockTick
 
-<emphasis role="bold">declare</emphasis> StockTick
-    <emphasis>@role</emphasis>( event )
-<emphasis role="bold">end</emphasis></programlisting>
-++++
+declare StockTick
+    @role( event )
+end
+----
 ====
 
 
@@ -251,15 +258,16 @@ If StockTick was a fact type declared in the DRL itself, instead of a previously
 
 .declaring a fact type and assigning it the event role
 ====
-++++
- <programlisting><emphasis role="bold">declare</emphasis> StockTick 
-    <emphasis>@role</emphasis>( event )
+[source]
+----
+declare StockTick 
+    @role( event )
 
     datetime : java.util.Date
     symbol : String
     price : double
-<emphasis role="bold">end</emphasis></programlisting>
-++++
+end
+----
 ====
 
 ==== @typesafe( <boolean> )
@@ -286,12 +294,13 @@ To tell the engine what attribute to use as the source of the event's timestamp,
 
 .declaring the VoiceCall timestamp attribute
 ====
-++++
-<programlisting><emphasis role="bold">declare</emphasis> VoiceCall
-    <emphasis>@role</emphasis>( event )
-    <emphasis>@timestamp</emphasis>( callDateTime )
-<emphasis role="bold">end</emphasis></programlisting>
-++++
+[source]
+----
+declare VoiceCall
+    @role( event )
+    @timestamp( callDateTime )
+end
+----
 ====
 
 ==== @duration( <attribute name> )
@@ -312,13 +321,14 @@ So, for our VoiceCall fact type, the declaration would be:
 
 .declaring the VoiceCall duration attribute
 ====
-++++
-<programlisting><emphasis role="bold">declare</emphasis> VoiceCall
-    <emphasis>@role</emphasis>( event )
-    <emphasis>@timestamp</emphasis>( callDateTime )
-    <emphasis>@duration</emphasis>( callDuration )
-<emphasis role="bold">end</emphasis></programlisting>
-++++
+[source]
+----
+declare VoiceCall
+    @role( event )
+    @timestamp( callDateTime )
+    @duration( callDuration )
+end
+----
 ====
 
 ==== @expires( <time interval> )
@@ -355,14 +365,15 @@ So, to declare that the VoiceCall facts should be expired after 1 hour and 35 mi
 
 .declaring the expiration offset for the VoiceCall events
 ====
-++++
-<programlisting><emphasis role="bold">declare</emphasis> VoiceCall
-    <emphasis>@role</emphasis>( event )
-    <emphasis>@timestamp</emphasis>( callDateTime )
-    <emphasis>@duration</emphasis>( callDuration )
-    <emphasis>@expires</emphasis>( 1h35m )
-<emphasis role="bold">end</emphasis></programlisting>
-++++
+[source]
+----
+declare VoiceCall
+    @role( event )
+    @timestamp( callDateTime )
+    @duration( callDuration )
+    @expires( 1h35m )
+end
+----
 ====
 
 
@@ -376,11 +387,12 @@ The boolean parameter that was used in the insert() method in the Drools 4 API i
 
 .@propertyChangeSupport
 ====
-++++
-<programlisting><emphasis role="bold">declare</emphasis> Person
-  <emphasis role="italic">@propertyChangeSupport</emphasis>
-<emphasis role="bold">end</emphasis></programlisting>
-++++
+[source]
+----
+declare Person
+    @propertyChangeSupport
+end
+----
 ====
 
 ==== @propertyReactive
@@ -409,13 +421,14 @@ For instance:
 
 .example of @key declarations for a type
 ====
-++++
-<programlisting><emphasis role="bold">declare</emphasis> Person
+[source]
+----
+declare Person
     firstName : String @key
     lastName : String @key
     age : int
-<emphasis role="bold">end</emphasis></programlisting>
-++++
+end
+----
 ====
 
 
@@ -442,24 +455,29 @@ Otherwise we might assume it was a boolean expression, which is how it could be 
 You can mix positional and named arguments on a pattern by using the semicolon ';' to separate them.
 Any variables used in a positional that have not yet been bound will be bound to the field that maps to that position.
 
-++++
-<programlisting><emphasis role="bold">declare</emphasis> Cheese
+====
+[source]
+----
+declare Cheese
     name : String
     shop : String
     price : int
-<emphasis role="bold">end</emphasis></programlisting>
-++++
+end
+----
+====
 
 The default order is the declared order, but this can be overridden using @position
 
-++++
-<programlisting><emphasis role="bold">declare</emphasis> Cheese
-    name : String <emphasis role="italic">@position(1)</emphasis>
-    shop : String <emphasis role="italic">@position(2)</emphasis>
-    price : int <emphasis role="italic">@position(0)</emphasis>
-<emphasis role="bold">end</emphasis></programlisting>
-++++
-
+====
+[source]
+----
+declare Cheese
+    name : String @position(1)
+    shop : String @position(2)
+    price : int @position(0)
+end
+----
+====
 
 The @Position annotation, in the org.drools.definition.type package, can be used to annotate original pojos on the classpath.
 Currently only fields on classes can be annotated.
@@ -469,6 +487,7 @@ Example patterns, with two constraints and a binding.
 Remember semicolon ';' is used to differentiate the positional section from the named argument section.
 Variables and literals and expressions using just literals are supported in positional arguments, but not variables.
 
+====
 [source]
 ----
 Cheese( "stilton", "Cheese Shop", p; )
@@ -476,25 +495,29 @@ Cheese( "stilton", "Cheese Shop"; p : price )
 Cheese( "stilton"; shop == "Cheese Shop", p : price )
 Cheese( name == "stilton"; shop == "Cheese Shop", p : price )
 ----
+====
 
 @Position is inherited when beans extend each other; while not recommended, two fields may have the same @position value, and not all consecutive values need be declared.
 If a @position is repeated, the conflict is solved using inheritance (fields in the superclass have the precedence) and the declaration order.
 If a @position value is missing, the first field without an explicit @position (if any) is selected to fill the gap.
 As always, conflicts are resolved by inheritance and declaration order.
 
-++++
-<programlisting><emphasis role="bold">declare</emphasis> Cheese
+====
+[source]
+----
+declare Cheese
     name : String 
-    shop : String <emphasis role="italic">@position(2)</emphasis>
-    price : int <emphasis role="italic">@position(0)</emphasis>
-<emphasis role="bold">end</emphasis>
+    shop : String @position(2)
+    price : int @position(0)
+end
 
-<emphasis role="bold">declare</emphasis> SeasonedCheese <emphasis role="bold">extends</emphasis> Cheese
-    year : Date <emphasis role="italic">@position(0)</emphasis>
-    origin : String <emphasis role="italic">@position(6)</emphasis>
+declare SeasonedCheese extends Cheese
+    year : Date @position(0)
+    origin : String @position(6)
     country : String    
-<emphasis role="bold">end</emphasis></programlisting>
-++++
+end
+----
+====
 
 In the example, the field order would be : price (@position 0 in the superclass), year (@position 0 in the subclass), name (first field with no @position), shop (@position 2), country (second field without @position), origin.
 
@@ -508,14 +531,15 @@ For instance, if there is a class org.drools.examples.Person, and one wants to d
 
 .Declaring metadata for an existing type
 ====
-++++
-<programlisting><emphasis role="bold">import</emphasis> org.drools.examples.Person
+[source]
+----
+import org.drools.examples.Person
 
-<emphasis role="bold">declare</emphasis> Person
-    <emphasis>@author</emphasis>( Bob )
-    <emphasis>@dateOfCreation</emphasis>( 01-Feb-2009 )
-<emphasis role="bold">end</emphasis></programlisting>
-++++
+declare Person
+    @author( Bob )
+    @dateOfCreation( 01-Feb-2009 )
+end
+----
 ====
 
 
@@ -523,12 +547,13 @@ Instead of using the import, it is also possible to reference the class by its f
 
 .Declaring metadata using the fully qualified class name
 ====
-++++
- <programlisting><emphasis role="bold">declare</emphasis> org.drools.examples.Person
-    <emphasis>@author</emphasis>( Bob )
-    <emphasis>@dateOfCreation</emphasis>( 01-Feb-2009 )
-<emphasis role="bold">end</emphasis></programlisting>
-++++
+[source]
+----
+declare org.drools.examples.Person
+    @author( Bob )
+    @dateOfCreation( 01-Feb-2009 )
+end
+----
 ====
 
 == Parametrized constructors for declared types
@@ -538,15 +563,16 @@ Generate constructors with parameters for declared types.
 
 Example: for a declared type like the following:
 
-++++
-<programlisting><emphasis role="bold">declare</emphasis> Person
-    firstName : String <emphasis role="italic">@key</emphasis>
-    lastName : String <emphasis role="italic">@key</emphasis>
+====
+[source]
+----
+declare Person
+    firstName : String @key
+    lastName : String @key
     age : int
-<emphasis role="bold">end</emphasis>
-</programlisting>
-++++
-
+end
+----
+====
 
 The compiler will implicitly generate 3 constructors: one without parameters, one with the @key fields, and one with all fields.
 
@@ -578,17 +604,18 @@ So, for instance, in the example below, `Person` will belong to the `org.drools.
 
 .Declaring a type in the org.drools.examples package
 ====
-++++
-<programlisting><emphasis role="bold">package</emphasis> org.drools.examples
+[source]
+----
+package org.drools.examples
 
-<emphasis role="bold">import</emphasis> java.util.Date
+import java.util.Date
 
-<emphasis role="bold">declare</emphasis> Person
+declare Person
     name : String
     dateOfBirth : Date
     address : Address
-<emphasis role="bold">end</emphasis></programlisting>
-++++
+end
+----
 ====
 
 
@@ -644,17 +671,20 @@ Type declarations now support 'extends' keyword for inheritance
 
 In order to extend a type declared in Java by a DRL declared subtype, repeat the supertype in a declare statement without any fields.
 
-++++
-<programlisting>b org.people.Person
+====
+[source]
+----
+import org.people.Person
 
-<emphasis role="bold">declare</emphasis> Person <emphasis role="bold">end</emphasis>
+declare Person end
 
-<emphasis role="bold">declare</emphasis> Student <emphasis role="bold">extends</emphasis> Person
+declare Student extends Person
     school : String
-<emphasis role="bold">end</emphasis>
+end
 
-<emphasis role="bold">declare</emphasis> LongTermStudent <emphasis role="bold">extends</emphasis> Student
+declare LongTermStudent extends Student
     years : int
     course : String
-<emphasis role="bold">end</emphasis></programlisting>
-++++
+end
+----
+====


### PR DESCRIPTION
…section.

The declaring type section was heavily affected with code section formatting problem, after the migration from docbook to adoc - see example screenshot. 

![image](https://cloud.githubusercontent.com/assets/1699252/23296072/c0adfd2e-fa73-11e6-86dc-4d0920572358.png)

I seized the chance to just go ahead and correct manually. This is not done for the Traits section (yet) as that is pending the PR for moving into experimental section.