### PR TITLE
Fix broken drools-docs rendering

### DIFF
--- a/docs/drools-docs/topics/ReleaseNotes/ReleaseNotesDrools.6.5.0.Final-section.adoc
+++ b/docs/drools-docs/topics/ReleaseNotes/ReleaseNotesDrools.6.5.0.Final-section.adoc
@@ -73,7 +73,7 @@ A new type of MBean has been introduced in order to provide monitoring of the Ki
 The JMX objectnaming has been normalized to reflect the terminology used in the Kie API.
 A new type of MBean has been introduced in order to provide monitoring for Stateless KieSession, which was not available in previous releases.
 
-[cols="3", options="header"] 
+[cols="3", options="header"]
 .JMX objectname changes
 |===
 |MBean
@@ -96,6 +96,7 @@ A new type of MBean has been introduced in order to provide monitoring for State
 |n/a
 |`org.kie:kcontainerId=_{kcontainerId}_,kbaseId=_{kbaseId}_,ksessionType=Stateless,ksessionName=_{ksessionName}_`
 |===
+
 The KieSession MBeans consolidate the statistics data for all sessions instantiated under the same name.
 
 KieSession created via `JPAKnowledgeService`, will be monitored under a KieSession MBean having constant `{ksessionName}` valorized to `persistent`; this MBean is not managed by the KieContainer directly, hence it requires to be manually deregistered from JMX, when monitoring is no longer needed.

--- a/docs/drools-docs/topics/ReleaseNotes/ReleaseNotesDrools.7.0.0.Final-section.adoc
+++ b/docs/drools-docs/topics/ReleaseNotes/ReleaseNotesDrools.7.0.0.Final-section.adoc
@@ -831,14 +831,15 @@ the former example the result list will now contain
 ----
 [Mario>4, Sofia>3, Mario>3]
 ----
+
 == Breaking changes
 
 The KieSession option to control when timed rules have to be automatically executed has been renamed into `TimedRuleExecutionOption` fixing a typing mistake in its name which affected previous releases; the property has been aligned into `drools.timedRuleExecution`.
 
-[cols="3", options="header"] 
+[cols="3", options="header"]
 .Name changes
 |===
-| 
+|
 |previous releases
 |version `7.0.0.Final`
 
@@ -849,3 +850,4 @@ The KieSession option to control when timed rules have to be automatically execu
 |property
 |`drools.timedRuleExection`
 |`drools.timedRuleExecution`
+|===


### PR DESCRIPTION
The table was not properly closed via |===.